### PR TITLE
Build with parsers 0.3

### DIFF
--- a/src/Text/Trifecta/Combinators.hs
+++ b/src/Text/Trifecta/Combinators.hs
@@ -24,6 +24,7 @@ module Text.Trifecta.Combinators
   ) where
 
 import Control.Applicative
+import Control.Monad (MonadPlus)
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Identity
 import Control.Monad.Trans.RWS.Lazy as Lazy
@@ -40,7 +41,7 @@ import Text.Trifecta.Delta
 import Text.Trifecta.Rendering
 import Prelude hiding (span)
 
-class TokenParsing m => DeltaParsing m where
+class (MonadPlus m, TokenParsing m) => DeltaParsing m where
   -- | Retrieve the contents of the current line (from the beginning of the line)
   line     :: m ByteString
   position :: m Delta

--- a/trifecta.cabal
+++ b/trifecta.cabal
@@ -56,7 +56,7 @@ library
     hashable             >= 1.1.2.1 && < 1.2,
     keys                 == 3.0.*,
     mtl                  >= 2.0.1   && < 2.2,
-    parsers              == 0.2.*,
+    parsers              == 0.3.*,
     reducers             == 3.0.*,
     semigroups           >= 0.8.3.1 && < 0.9,
     terminfo             >= 0.3.2   && < 0.4,


### PR DESCRIPTION
This minimal change makes trifecta build with parsers 0.3, but I don't know if it's the correct change.
