### PR TITLE
Add Text.Trifecta.Result to Text.Trifecta exports

### DIFF
--- a/src/Text/Trifecta.hs
+++ b/src/Text/Trifecta.hs
@@ -14,19 +14,19 @@ module Text.Trifecta
   , module Text.Trifecta.Highlight
   , module Text.Trifecta.Parser
   , module Text.Trifecta.Combinators
+  , module Text.Trifecta.Result
   , module Text.Trifecta.Rope
   , module Text.Parser.Combinators
   , module Text.Parser.Char
   , module Text.Parser.Token
-  , module Text.Parser.Result
   ) where
 
 import Text.Trifecta.Rendering
 import Text.Trifecta.Highlight
 import Text.Trifecta.Parser
 import Text.Trifecta.Combinators
+import Text.Trifecta.Result
 import Text.Trifecta.Rope
 import Text.Parser.Combinators
 import Text.Parser.Char
 import Text.Parser.Token
-import Text.Parser.Result


### PR DESCRIPTION
I can't quite make out whether this was deliberate or an oversight: You haven't exported Text.Trifecta.Result from Text.Trifecta, meaning the `Success` and `Failure` constructors of the Result type are not visible. It broke my compile (when attempting to upgrade from 0.53) so I thought I should mention it. If mere oversight, patch attached. Or was there something else I was supposed to import instead?

AfC
