### PR TITLE
Use lens>=4 newtype names, bump deps

### DIFF
--- a/src/Text/Trifecta/Result.hs
+++ b/src/Text/Trifecta/Result.hs
@@ -100,21 +100,21 @@ data Result a
 
 -- | A 'Prism' that lets you embed or retrieve a 'Result' in a potentially larger type.
 class AsResult p f s t a b | s -> a, t -> b, s b -> t, t a -> s where
-  _Result :: Overloaded p f s t (Result a) (Result b)
+  _Result :: Optic p f s t (Result a) (Result b)
 
 instance AsResult p f (Result a) (Result b) a b where
   _Result = id
   {-# INLINE _Result #-}
 
 -- | The 'Prism' for the 'Success' constructor of 'Result'
-_Success :: (AsResult p f s t a b, Choice p, Applicative f) => Overloaded p f s t a b
+_Success :: (AsResult p f s t a b, Choice p, Applicative f) => Optic p f s t a b
 _Success = _Result . dimap seta (either id id) . right' . rmap (fmap Success) where
   seta (Success a) = Right a
   seta (Failure d) = Left (pure (Failure d))
 {-# INLINE _Success #-}
 
 -- | The 'Prism' for the 'Failure' constructor of 'Result'
-_Failure :: (AsResult p f s s a a, Choice p, Applicative f) => Overloaded' p f s Doc
+_Failure :: (AsResult p f s s a a, Choice p, Applicative f) => Optic' p f s Doc
 _Failure = _Result . dimap seta (either id id) . right' . rmap (fmap Failure) where
   seta (Failure d) = Right d
   seta (Success a) = Left (pure (Success a))

--- a/trifecta.cabal
+++ b/trifecta.cabal
@@ -56,7 +56,7 @@ library
     fingertree           >= 0.1     && < 0.2,
     ghc-prim,
     hashable             >= 1.2.1   && < 1.3,
-    lens                 >= 3.10    && < 4,
+    lens                 >= 4.0     && < 5,
     mtl                  >= 2.0.1   && < 2.2,
     parsers              >= 0.10    && < 1,
     reducers             >= 3.10    && < 4,


### PR DESCRIPTION
This is the simplest change to work with lens 4 (I think); I'd push it directly but I'm not sure if you intend to maintain compatibility with lens 3?
