### PR TITLE
GHC.Exts exports a toList/fromList with ghc-7.8

### DIFF
--- a/src/Text/Trifecta/Util/Array.hs
+++ b/src/Text/Trifecta/Util/Array.hs
@@ -56,7 +56,20 @@ import qualified Data.Traversable as Traversable
 import Control.Applicative (Applicative)
 import Control.DeepSeq
 import Control.Monad.ST
-import GHC.Exts
+import GHC.Exts (
+      Array#,
+      copyArray#,
+      copyMutableArray#,
+      indexArray#,
+      Int(I#),
+      MutableArray#,
+      newArray#,
+      readArray#,
+      sizeofArray#,
+      sizeofMutableArray#,
+      thawArray#,
+      unsafeFreezeArray#,
+      writeArray#)
 import GHC.ST (ST(..))
 import Prelude hiding (filter, foldr, length, map, read)
 


### PR DESCRIPTION
you could also `import GHC.Exts hiding (toList, fromList)`, but that's a warning with ghc-7.6 and an error with earlier versions of ghc.
