### PR TITLE
Fix building with base-4.8.0.0 and deepseq-1.4

### DIFF
--- a/src/Text/Trifecta/Delta.hs
+++ b/src/Text/Trifecta/Delta.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, DeriveGeneric #-}
+{-# LANGUAGE CPP, DeriveDataTypeable, DeriveGeneric #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Text.Trifecta.Delta
@@ -26,7 +26,9 @@ import Data.Hashable
 import Data.Int
 import Data.Data
 import Data.Word
+#if !(MIN_VERSION_base(4,8,0))
 import Data.Foldable
+#endif
 import Data.Function (on)
 import Data.FingerTree hiding (empty)
 import Data.ByteString as Strict hiding (empty)

--- a/src/Text/Trifecta/Util/Array.hs
+++ b/src/Text/Trifecta/Util/Array.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE BangPatterns, CPP, MagicHash, Rank2Types, UnboxedTuples #-}
+
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Text.Trifecta.Util.Array
@@ -53,7 +57,9 @@ module Text.Trifecta.Util.Array
   ) where
 
 import qualified Data.Traversable as Traversable
+#if !(MIN_VERSION_base(4,8,0))
 import Control.Applicative (Applicative)
+#endif
 import Control.DeepSeq
 import Control.Monad.ST
 import GHC.Exts (
@@ -71,7 +77,12 @@ import GHC.Exts (
       unsafeFreezeArray#,
       writeArray#)
 import GHC.ST (ST(..))
-import Prelude hiding (filter, foldr, length, map, read)
+import Prelude hiding
+  ( filter, foldr, length, map, read
+#if MIN_VERSION_base(4,8,0)
+  , traverse
+#endif
+  )
 
 ------------------------------------------------------------------------
 

--- a/src/Text/Trifecta/Util/IntervalMap.hs
+++ b/src/Text/Trifecta/Util/IntervalMap.hs
@@ -1,6 +1,11 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
+
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Text.Trifecta.Util.IntervalMap
@@ -51,7 +56,9 @@ import Control.Applicative hiding (empty)
 import Control.Lens hiding ((<|),(|>))
 import qualified Data.FingerTree as FT
 import Data.FingerTree (FingerTree, Measured(..), ViewL(..), (<|), (><))
+#if !(MIN_VERSION_base(4,8,0))
 import Data.Foldable (Foldable(foldMap))
+#endif
 import Data.Semigroup
 import Data.Semigroup.Reducer
 import Data.Semigroup.Union

--- a/src/Text/Trifecta/Util/It.hs
+++ b/src/Text/Trifecta/Util/It.hs
@@ -38,9 +38,14 @@ import Control.Comonad
 import Control.Monad
 import Data.ByteString as Strict
 import Data.ByteString.Lazy as Lazy
+import Data.Semigroup
 import Text.Trifecta.Rope
 import Text.Trifecta.Delta
 import Text.Trifecta.Util.Combinators as Util
+
+#if MIN_VERSION_base(4,8,0)
+import Prelude hiding (mempty)
+#endif
 
 data It r a
   = Pure a

--- a/src/Text/Trifecta/Util/It.hs
+++ b/src/Text/Trifecta/Util/It.hs
@@ -1,8 +1,13 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE TypeFamilies #-}
+
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Text.Trifecta.Util.It
@@ -26,10 +31,11 @@ module Text.Trifecta.Util.It
   , sliceIt
   ) where
 
+#if !(MIN_VERSION_base(4,8,0))
 import Control.Applicative
+#endif
 import Control.Comonad
 import Control.Monad
-import Data.Semigroup
 import Data.ByteString as Strict
 import Data.ByteString.Lazy as Lazy
 import Text.Trifecta.Rope

--- a/trifecta.cabal
+++ b/trifecta.cabal
@@ -63,7 +63,7 @@ library
     semigroups           >= 0.8.3.1 && < 1,
     transformers         >= 0.2     && < 0.5,
     unordered-containers >= 0.2.1   && < 0.3,
-    utf8-string          >= 0.3.6   && < 0.4
+    utf8-string          >= 0.3.6   && < 1.1
 
   default-language: Haskell2010
   hs-source-dirs:   src

--- a/trifecta.cabal
+++ b/trifecta.cabal
@@ -52,7 +52,7 @@ library
     charset              >= 0.3.5.1 && < 1,
     comonad              >= 4       && < 5,
     containers           >= 0.3     && < 0.6,
-    deepseq              >= 1.2.0.1 && < 1.4,
+    deepseq              >= 1.2.0.1 && < 1.5,
     fingertree           >= 0.1     && < 0.2,
     ghc-prim,
     hashable             >= 1.2.1   && < 1.3,


### PR DESCRIPTION
This commit adds some CPP pragmas to get around some import conflicts and warnings that arise from `Prelude` exporting `Applicative(..)`, `Foldable(..)`, and `Traversable(..)` in `base-4.8.0.0`, and it bumps `deepseq`'s upper version bounds.