### PR TITLE
Be more selective about Blaze imports

### DIFF
--- a/src/Text/Trifecta/Highlight.hs
+++ b/src/Text/Trifecta/Highlight.hs
@@ -32,7 +32,7 @@ import Text.Blaze
 import Text.Blaze.Html5 hiding (a,b,i)
 import qualified Text.Blaze.Html5 as Html5
 import Text.Blaze.Html5.Attributes hiding (title,id)
-import Text.Blaze.Internal
+import Text.Blaze.Internal (MarkupM(Empty, Leaf))
 import Text.Parser.Token.Highlight
 import Text.PrettyPrint.ANSI.Leijen hiding ((<>))
 import Text.Trifecta.Util.IntervalMap as IM


### PR DESCRIPTION
This prevents a build failure due to ambiguous identifier when building against blaze-builder-0.3.3.4, blaze-markup-0.6.3.0, and blaze-html-0.7.0.3.

The error was:

```
src/Text/Trifecta/Highlight.hs:46:15:
    Ambiguous occurrence ‘Comment’
    It could refer to either ‘Text.Blaze.Internal.Comment’,
                             imported from ‘Text.Blaze.Internal’ at src/Text/Trifecta/Highlight.hs:35:1-26
                          or ‘Text.Parser.Token.Highlight.Comment’,
                             imported from ‘Text.Parser.Token.Highlight’ at src/Text/Trifecta/Highlight.hs:36:1-34
```