### PR TITLE
Fixed lens breakage, silenced AMP/FTP warnings, added profunctors dependency

### DIFF
--- a/src/Text/Trifecta/Highlight.hs
+++ b/src/Text/Trifecta/Highlight.hs
@@ -21,7 +21,7 @@ module Text.Trifecta.Highlight
   , doc
   ) where
 
-import Control.Lens
+import Control.Lens hiding (Empty)
 import Data.Foldable as F
 import Data.Int (Int64)
 import Data.List (sort)

--- a/src/Text/Trifecta/Util/IntervalMap.hs
+++ b/src/Text/Trifecta/Util/IntervalMap.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -47,11 +48,13 @@ module Text.Trifecta.Util.IntervalMap
   , fromList
   ) where
 
+#if __GLASGOW_HASKELL__ < 710
 import Control.Applicative hiding (empty)
-import Control.Lens hiding ((<|),(|>))
+import Data.Foldable (Foldable(foldMap))
+#endif
+import Control.Lens hiding ((<|),(|>),(:<))
 import qualified Data.FingerTree as FT
 import Data.FingerTree (FingerTree, Measured(..), ViewL(..), (<|), (><))
-import Data.Foldable (Foldable(foldMap))
 import Data.Semigroup
 import Data.Semigroup.Reducer
 import Data.Semigroup.Union

--- a/trifecta.cabal
+++ b/trifecta.cabal
@@ -59,6 +59,7 @@ library
     lens                 >= 4.0     && < 5,
     mtl                  >= 2.0.1   && < 2.3,
     parsers              >= 0.12.1  && < 1,
+    profunctors          >= 4.0     && < 6,
     reducers             >= 3.10    && < 4,
     semigroups           >= 0.8.3.1 && < 1,
     transformers         >= 0.2     && < 0.5,


### PR DESCRIPTION
Hid new lens-exports to avoid ambiguous name warnings.

Added conditional compilation CPP to the imports to avoid unused import
warnings created by the Applicative-Monad and Foldable-Traversable proposals.

Added profunctors dependency for @treeowl's new Profunctor instances. Bounds
are equal to minimum of lens-4.0 (min lens version for trifecta) and the max of
lens-4.13 (current max lens version for trifecta).