### PR TITLE
Try to make trifecta forward`-Wcompat`ible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist/
 dist-newstyle/
+.ghc.environment.*
 .hsenv/
 docs
 wiki

--- a/src/Text/Trifecta/Parser.hs
+++ b/src/Text/Trifecta/Parser.hs
@@ -130,16 +130,8 @@ instance Semigroup a => Semigroup (Parser a) where
   (<>) = liftA2 (<>)
   {-# INLINE (<>) #-}
 
-{- In order to silence '-Wnoncanonical-monoid-instances' we'd need to
-   change the type-signature to emulate the not-yet existing superclass
-   relationship:
-
 instance (Semigroup a, Monoid a) => Monoid (Parser a) where
   mappend = (<>)
-  mempty = pure mempty
--}
-instance Monoid a => Monoid (Parser a) where
-  mappend = liftA2 mappend
   {-# INLINE mappend #-}
 
   mempty = pure mempty

--- a/src/Text/Trifecta/Result.hs
+++ b/src/Text/Trifecta/Result.hs
@@ -100,7 +100,10 @@ class Errable m where
 
 instance Monoid ErrInfo where
   mempty = ErrInfo mempty mempty
-  mappend (ErrInfo xs d1) (ErrInfo ys d2) = ErrInfo (vsep [xs, ys]) (max d1 d2)
+  mappend = (<>)
+
+instance Semigroup ErrInfo where
+  ErrInfo xs d1 <> ErrInfo ys d2 = ErrInfo (vsep [xs, ys]) (max d1 d2)
 
 -- | The result of parsing. Either we succeeded or something went wrong.
 data Result a

--- a/src/Text/Trifecta/Util/IntervalMap.hs
+++ b/src/Text/Trifecta/Util/IntervalMap.hs
@@ -129,9 +129,12 @@ data IntInterval v = NoInterval | IntInterval (Interval v) v
 
 instance Ord v => Monoid (IntInterval v) where
   mempty = NoInterval
-  NoInterval `mappend` i  = i
-  i `mappend` NoInterval  = i
-  IntInterval _ hi1 `mappend` IntInterval int2 hi2 =
+  mappend = (<>)
+
+instance Ord v => Semigroup (IntInterval v) where
+  NoInterval <> i  = i
+  i <> NoInterval  = i
+  IntInterval _ hi1 <> IntInterval int2 hi2 =
     IntInterval int2 (max hi1 hi2)
 
 instance Ord v => Measured (IntInterval v) (Node v a) where
@@ -194,7 +197,10 @@ instance Ord v => HasUnion0 (IntervalMap v a) where
 
 instance Ord v => Monoid (IntervalMap v a) where
   mempty = empty
-  mappend = union
+  mappend = (<>)
+
+instance Ord v => Semigroup (IntervalMap v a) where
+  (<>) = union
 
 -- | /O(n)/. Add a delta to each interval in the map
 offset :: (Ord v, Monoid v) => v -> IntervalMap v a -> IntervalMap v a

--- a/src/Text/Trifecta/Util/It.hs
+++ b/src/Text/Trifecta/Util/It.hs
@@ -77,7 +77,7 @@ simplifyIt (It _ k) r = k r
 simplifyIt pa _       = pa
 
 instance Monad (It r) where
-  return = Pure
+  return = pure
   Pure a >>= f = f a
   It a k >>= f = It (extract (f a)) $ \r -> case k r of
     It a' k' -> It (indexIt (f a') r) $ k' >=> f

--- a/trifecta.cabal
+++ b/trifecta.cabal
@@ -82,6 +82,11 @@ library
   hs-source-dirs:   src
   ghc-options:      -O2 -Wall -fobject-code
 
+  -- See https://ghc.haskell.org/trac/ghc/wiki/Migration/8.0#base-4.9.0.0
+  if impl(ghc >= 8.0)
+    ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
+  else
+    build-depends: fail == 4.9.*
 
 test-suite doctests
   type:             exitcode-stdio-1.0


### PR DESCRIPTION
The patch doesn't succeed in making 100% forward compatible; see note at

    instance Monoid a => Monoid (Parser a) where

about why that instance still triggers a warning.

NB: trifecta may need minor version increment, as new instances are defined!