### PR TITLE
ansi-wl-pprint has Semigroup Doc

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+1.7.1.1
+-------
+
+* Support `ansi-wl-pprint-0.6.8`
+
 1.7.1
 -----
 * Support `doctest-0.12`

--- a/src/Text/Trifecta/Instances.hs
+++ b/src/Text/Trifecta/Instances.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 -----------------------------------------------------------------------------
 -- |
@@ -12,8 +13,10 @@
 -----------------------------------------------------------------------------
 module Text.Trifecta.Instances () where
 
+#if !MIN_VERSION_ansi_wl_pprint(0,6,8)
 import Text.PrettyPrint.ANSI.Leijen
 import qualified Data.Semigroup as Data
 
 instance Data.Semigroup Doc where
   (<>) = (<>)
+#endif

--- a/trifecta.cabal
+++ b/trifecta.cabal
@@ -1,6 +1,6 @@
 name:          trifecta
 category:      Text, Parsing, Diagnostics, Pretty Printer, Logging
-version:       1.7.1
+version:       1.7.1.1
 license:       BSD3
 cabal-version: >= 1.10
 license-file:  LICENSE


### PR DESCRIPTION
We'll need to adjust upper bumps for released versions of `trifecta`, but let's first see the matrix turning red (https://matrix.hackage.haskell.org/package/trifecta)