### PR TITLE
Rewrite `stepParser` to remove the `ByteString` argument

### DIFF
--- a/src/Text/Trifecta/Parser.hs
+++ b/src/Text/Trifecta/Parser.hs
@@ -301,8 +301,9 @@ stepResult r (Failure xs) = StepFail r xs
 
 stepIt :: It Rope a -> Step a
 stepIt = go mempty where
-  go r (Pure a) = StepDone r a
-  go r (It a k) = StepCont r (pure a) $ \s -> go s (k s)
+  go r m = case simplifyIt m r of
+    Pure a -> StepDone r a
+    It a k -> StepCont r (pure a) $ \r' -> go r' (k r')
 {-# INLINE stepIt #-}
 
 data Stepping a
@@ -317,19 +318,21 @@ stepParser (Parser p) d0 bs0 = go mempty $ p eo ee co ce d0 bs0 where
   ee e         = Pure (EE e)
   co a es d bs = Pure (CO a es d bs)
   ce errInf    = Pure (CE errInf)
-  go r (Pure (EO a _))     = StepDone r a
-  go r (Pure (EE e))       = StepFail r $
-                              let errDoc = explain (renderingCaret d0 bs0) e
-                              in  ErrInfo errDoc (_finalDeltas e)
-  go r (Pure (CO a _ _ _)) = StepDone r a
-  go r (Pure (CE d))       = StepFail r d
-  go r (It ma k)           = StepCont r (case ma of
-                                EO a _     -> Success a
-                                EE e       -> Failure $
-                                  ErrInfo (explain (renderingCaret d0 bs0) e) (d0 : _finalDeltas e)
-                                CO a _ _ _ -> Success a
-                                CE d       -> Failure d
-                              ) (go <*> k)
+
+  go r m = case simplifyIt m r of
+    Pure (EO a _)     -> StepDone r a
+    Pure (EE e)       -> StepFail r $
+                          let errDoc = explain (renderingCaret d0 bs0) e
+                          in  ErrInfo errDoc (_finalDeltas e)
+    Pure (CO a _ _ _) -> StepDone r a
+    Pure (CE d)       -> StepFail r d
+    It ma k           -> StepCont r (case ma of
+                           EO a _     -> Success a
+                           EE e       -> Failure $
+                             ErrInfo (explain (renderingCaret d0 bs0) e) (d0 : _finalDeltas e)
+                           CO a _ _ _ -> Success a
+                           CE d       -> Failure d
+                         ) (\r' -> go r' (k r'))
 {-# INLINE stepParser #-}
 
 -- | @parseFromFile p filePath@ runs a parser @p@ on the

--- a/src/Text/Trifecta/Result.hs
+++ b/src/Text/Trifecta/Result.hs
@@ -156,3 +156,8 @@ instance Alternative Result where
   {-# INLINE (<|>) #-}
   empty = Failure mempty
   {-# INLINE empty #-}
+
+instance Monad Result where
+  return = pure
+  Success a >>= m = m a
+  Failure e >>= _ = Failure e


### PR DESCRIPTION
The initial `ByteString` was used as the initial value for the parser's current
line of input. This led to problems with incremental parsing:

    > starve (feed "foo" (stepParser (                  many anyChar) mempty "bar"))
    Success "bar"

    > starve (feed "foo" (stepParser (release mempty *> many anyChar) mempty "bar"))
    Success "foo"

The initial chunk of input *should* be obtained from the input itself, using
`rewindIt` (that's basically what `release mempty` in the second example does).

This is a breaking change, since we remove an argument from the `stepParser`
function. However, client code usually relies on the more high-level
`parseString`/`parseByteString`, so this should not have too much impact.

Fixes #21.

(This PR is based on #75, otherwise it would conflict.)