### PR TITLE
Add foldResult

### DIFF
--- a/src/Text/Trifecta/Result.hs
+++ b/src/Text/Trifecta/Result.hs
@@ -24,6 +24,7 @@ module Text.Trifecta.Result
   -- * Parse Results
     Result(..)
   , AsResult(..)
+  , foldResult
   , _Success
   , _Failure
   -- * Parsing Errors
@@ -113,6 +114,12 @@ data Result a
   = Success a
   | Failure ErrInfo
   deriving (Show,Functor,Foldable,Traversable)
+
+-- | Fold over a 'Result'
+foldResult :: (ErrInfo -> b) -> (a -> b) -> Result a -> b
+foldResult f g r = case r of
+  Failure e -> f e
+  Success a -> g a
 
 -- | A 'Prism' that lets you embed or retrieve a 'Result' in a potentially larger type.
 class AsResult s t a b | s -> a, t -> b, s b -> t, t a -> s where


### PR DESCRIPTION
Alternatively this could be named `result` in the style of `maybe` and `either`. That would give trifecta a shadowed binding warning we'd have to sort out, and would probably cause that warning in a bunch of user code as well. Thoughts?