### PR TITLE
Rendering gutter

### DIFF
--- a/src/Text/Trifecta/Rendering.hs
+++ b/src/Text/Trifecta/Rendering.hs
@@ -28,6 +28,7 @@ module Text.Trifecta.Rendering
   , rendered
   , Renderable(..)
   , Rendered(..)
+  , gutterEffects
   -- * Carets
   , Caret(..)
   , HasCaret(..)

--- a/src/Text/Trifecta/Rendering.hs
+++ b/src/Text/Trifecta/Rendering.hs
@@ -300,6 +300,7 @@ window c l w
   | otherwise   = (c-w2, c+w2)
   where w2 = div w 2
 
+-- | ANSI terminal style for rendering the gutter.
 gutterEffects :: [SGR]
 gutterEffects = [SetColor Foreground Vivid Blue]
 

--- a/src/Text/Trifecta/Rendering.hs
+++ b/src/Text/Trifecta/Rendering.hs
@@ -275,17 +275,17 @@ f .# Rendering d ll lb s g = Rendering d ll lb s $ \e l -> f e $ g e l
 instance Pretty Rendering where
   pretty (Rendering d ll _ l f) = nesting $ \k -> columns $ \mn -> go (fromIntegral (fromMaybe 80 mn - k)) where
     go cols = align (vsep (P.map ln [t..b])) where
-      (lo, hi) = window (column d) ll (min (max (cols - 5 - gutterWidth) 30) 200)
+      (lo, hi) = window (column d) ll (min (max (cols - 5 - fromIntegral gutterWidth) 30) 200)
       a = f d $ l $ array ((0,lo),(-1,hi)) []
       ((t,_),(b,_)) = bounds a
-      n = case d of
+      n = show $ case d of
         Lines      n' _ _ _ -> 1 + n'
         Directed _ n' _ _ _ -> 1 + n'
         _                   -> 1
       separator = char '|'
-      gutterWidth = floor (logBase (fromIntegral n) 10 :: Float)
-      gutter = pretty (fromIntegral n :: Int) <+> separator
-      margin = fill (fromIntegral gutterWidth) space <+> separator
+      gutterWidth = P.length n
+      gutter = pretty n <+> separator
+      margin = fill gutterWidth space <+> separator
       ln y = (sgr gutterEffects (if y == 0 then gutter else margin) <+>)
            $ hcat
            $ P.map (\g -> sgr (fst (P.head g)) (pretty (P.map snd g)))

--- a/src/Text/Trifecta/Rendering.hs
+++ b/src/Text/Trifecta/Rendering.hs
@@ -274,10 +274,19 @@ f .# Rendering d ll lb s g = Rendering d ll lb s $ \e l -> f e $ g e l
 instance Pretty Rendering where
   pretty (Rendering d ll _ l f) = nesting $ \k -> columns $ \mn -> go (fromIntegral (fromMaybe 80 mn - k)) where
     go cols = align (vsep (P.map ln [t..b])) where
-      (lo, hi) = window (column d) ll (min (max (cols - 2) 30) 200)
+      (lo, hi) = window (column d) ll (min (max (cols - 5 - gutterWidth) 30) 200)
       a = f d $ l $ array ((0,lo),(-1,hi)) []
       ((t,_),(b,_)) = bounds a
-      ln y = hcat
+      n = case d of
+        Lines      n' _ _ _ -> 1 + n'
+        Directed _ n' _ _ _ -> 1 + n'
+        _                   -> 1
+      separator = char '|'
+      gutterWidth = floor (logBase (fromIntegral n) 10 :: Float)
+      gutter = pretty (fromIntegral n :: Int) <+> separator
+      margin = fill (fromIntegral gutterWidth) space <+> separator
+      ln y = (sgr [SetColor Foreground Vivid Blue] (if y == 0 then gutter else margin) <+>)
+           $ hcat
            $ P.map (\g -> sgr (fst (P.head g)) (pretty (P.map snd g)))
            $ groupBy ((==) `on` fst)
            [ a ! (y,i) | i <- [lo..hi] ]

--- a/src/Text/Trifecta/Rendering.hs
+++ b/src/Text/Trifecta/Rendering.hs
@@ -335,8 +335,8 @@ instance Renderable (Rendered a) where
 -- | A 'Caret' marks a point in the input with a simple @^@ character.
 --
 -- >>> plain (pretty (addCaret (Columns 35 35) exampleRendering))
--- int main(int argc, char ** argv) { int; }<EOF>
---                                    ^
+-- 1 | int main(int argc, char ** argv) { int; }<EOF>
+--   |                                    ^
 data Caret = Caret !Delta {-# UNPACK #-} !ByteString deriving (Eq,Ord,Show,Data,Typeable,Generic)
 
 class HasCaret t where
@@ -441,8 +441,8 @@ addSpan s e r = drawSpan s e .# r
 -- 'Span' is a line.
 --
 -- >>> plain (pretty (addSpan (Columns 35 35) (Columns 38 38) exampleRendering))
--- int main(int argc, char ** argv) { int; }<EOF>
---                                    ~~~
+-- 1 | int main(int argc, char ** argv) { int; }<EOF>
+--   |                                    ~~~
 data Span = Span !Delta !Delta {-# UNPACK #-} !ByteString deriving (Eq,Ord,Show,Data,Typeable,Generic)
 
 class HasSpan t where
@@ -504,9 +504,9 @@ addFixit s e rpl r = drawFixit s e rpl .# r
 -- | A 'Fixit' is a 'Span' with a suggestion.
 --
 -- >>> plain (pretty (addFixit (Columns 35 35) (Columns 38 38) "Fix this!" exampleRendering))
--- int main(int argc, char ** argv) { int; }<EOF>
---                                    ~~~
---                                    Fix this!
+-- 1 | int main(int argc, char ** argv) { int; }<EOF>
+--   |                                    ~~~
+--   |                                    Fix this!
 data Fixit = Fixit
   { _fixitSpan :: {-# UNPACK #-} !Span
     -- ^ 'Span' where the error occurred

--- a/src/Text/Trifecta/Rendering.hs
+++ b/src/Text/Trifecta/Rendering.hs
@@ -285,7 +285,7 @@ instance Pretty Rendering where
       gutterWidth = floor (logBase (fromIntegral n) 10 :: Float)
       gutter = pretty (fromIntegral n :: Int) <+> separator
       margin = fill (fromIntegral gutterWidth) space <+> separator
-      ln y = (sgr [SetColor Foreground Vivid Blue] (if y == 0 then gutter else margin) <+>)
+      ln y = (sgr gutterEffects (if y == 0 then gutter else margin) <+>)
            $ hcat
            $ P.map (\g -> sgr (fst (P.head g)) (pretty (P.map snd g)))
            $ groupBy ((==) `on` fst)
@@ -298,6 +298,9 @@ window c l w
                            else (0  , w)
   | otherwise   = (c-w2, c+w2)
   where w2 = div w 2
+
+gutterEffects :: [SGR]
+gutterEffects = [SetColor Foreground Vivid Blue]
 
 data Rendered a = a :@ Rendering
   deriving Show

--- a/src/Text/Trifecta/Tutorial.hs
+++ b/src/Text/Trifecta/Tutorial.hs
@@ -65,7 +65,7 @@ parseExpr = parseAdd <|> parseLit
 -- @
 --
 -- > (interactive):1:8: error: expected: ")"
--- > (1 + 2 + 3))<EOF>
--- >        ^
+-- > 1 | (1 + 2 + 3))<EOF>
+-- >   |        ^
 examples :: docDummy
 examples = error "Haddock dummy for documentation"


### PR DESCRIPTION
This PR:

- [x] Adds gutters to the `Pretty` instance for `Rendering`, showing the current line number on source lines and padding caret/span/fixit lines to match.
- [x] Fixes #82.

<img width="357" alt="screen shot 2018-12-19 at 10 16 47 pm" src="https://user-images.githubusercontent.com/59671/50261714-d226f380-03db-11e9-90b6-06ba0f32e6d6.png">
