### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/trifecta.cabal
+++ b/trifecta.cabal
@@ -95,7 +95,6 @@ library
     prettyprinter-ansi-terminal >= 1.1     && < 2,
     profunctors                 >= 4.0     && < 6,
     reducers                    >= 3.10    && < 4,
-    semigroups                  >= 0.8.3.1 && < 1,
     transformers                >= 0.2     && < 0.6,
     unordered-containers        >= 0.2.1   && < 0.3,
     utf8-string                 >= 0.3.6   && < 1.1
@@ -110,7 +109,9 @@ library
     if !impl(ghc >= 8.8)
       ghc-options: -Wnoncanonical-monadfail-instances
   else
-    build-depends: fail == 4.9.*
+    build-depends:
+      fail                      == 4.9.*,
+      semigroups                >= 0.8.3.1 && < 1
 
 test-suite doctests
   type:              exitcode-stdio-1.0


### PR DESCRIPTION
They are not needed on newer GHC.